### PR TITLE
Fix: Hidden navigation settings for HW button devices

### DIFF
--- a/src/com/android/settings/gestures/SystemNavigationPreferenceController.java
+++ b/src/com/android/settings/gestures/SystemNavigationPreferenceController.java
@@ -23,10 +23,6 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.os.RemoteException;
-import android.view.Display;
-import android.view.IWindowManager;
-import android.view.WindowManagerGlobal;
 
 import com.android.settings.R;
 import com.android.settings.core.BasePreferenceController;
@@ -57,19 +53,9 @@ public class SystemNavigationPreferenceController extends BasePreferenceControll
     }
 
     static boolean isGestureAvailable(Context context) {
-        boolean hasNavigationBar = false;
-        final boolean configEnabled = context.getResources().getBoolean(
-                com.android.internal.R.bool.config_swipe_up_gesture_setting_available);
-
-        try {
-            IWindowManager windowManager = WindowManagerGlobal.getWindowManagerService();
-            hasNavigationBar = windowManager.hasNavigationBar(Display.DEFAULT_DISPLAY);
-        } catch (RemoteException ex) {
-            // no window manager? good luck with that
-        }
         // Skip if the swipe up settings are not available
-        // or if on-screen navbar is disabled (for devices with hardware keys)
-        if (!configEnabled || !hasNavigationBar) {
+        if (!context.getResources().getBoolean(
+                com.android.internal.R.bool.config_swipe_up_gesture_setting_available)) {
             return false;
         }
 


### PR DESCRIPTION
### Some devices with HW Buttons are unable to use Navigation settings [they become hidden] due to this, also there is need to set :
* config_showNavigationBar overlay to false
* qemu.hw.mainkeys=0 in system.prop
* https://github.com/Jrchintu/device_xiaomi_mido/commit/3f89bc4c24a0ddc56c2fb972cf160d0f11909738

This reverts commit 0a5737258af70240a5f926209dc9f08e6ffdd944.